### PR TITLE
Rename the module for the Customer.io fork

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,8 @@ jobs:
   build-and-test:
     runs-on:
 #      - windows-latest
-      - self-hosted
-      - ephemeral
-    
+      - ubuntu-latest
+
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,23 +3,31 @@ name: Build and Test
 
 on:
   push:
+    branches:
+      - main
   pull_request:
-  repository_dispatch:
-  schedule:
-     - cron: '05 5 1 * *' # <https://crontab.guru/#05_5_1_*_*> - "At 05:05 on day-of-month 1"  
+#  repository_dispatch:
+#  schedule:
+#     - cron: '05 5 1 * *' # <https://crontab.guru/#05_5_1_*_*> - "At 05:05 on day-of-month 1"
 
 
 jobs:
 
   build-and-test:
-    runs-on: windows-latest 
+    runs-on:
+#      - windows-latest
+      - self-hosted
+      - ephemeral
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     
     - name: Setup Go environment
-      uses: actions/setup-go@v2.2.0
+      uses: actions/setup-go@v5
+      with:
+        go-version: 1.22.3
+        cache: false
     
     - name: Build
       run: go build -v ./...

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# Fork of go-approval-tests
+
+This fork incorporates https://github.com/approvals/go-approval-tests/pull/41 , which has not been accepted yet by upstream. Once/if that PR is accepted, and merged, users of this fork can go back to using the original go-approval-tests.
+
+This fork renames the module to `customerio/go-approval-tests`. This avoids the use of `replace` directives in `go.mod`, which for modules that depend on other modules using `replace`.
+
+---
+
 # ApprovalTests.go
 
 ApprovalTests for [go](https://golang.org/)

--- a/approvals.go
+++ b/approvals.go
@@ -11,8 +11,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/approvals/go-approval-tests/reporters"
-	"github.com/approvals/go-approval-tests/utils"
+	"github.com/customerio/go-approval-tests/reporters"
+	"github.com/customerio/go-approval-tests/utils"
 )
 
 var (

--- a/approvals_test.go
+++ b/approvals_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/approvals/go-approval-tests/reporters"
+	"github.com/customerio/go-approval-tests/reporters"
 )
 
 func TestMain(m *testing.M) {

--- a/examples_helper_test.go
+++ b/examples_helper_test.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"strings"
 
-	approvals "github.com/approvals/go-approval-tests"
+	approvals "github.com/customerio/go-approval-tests"
 )
 
 var (

--- a/examples_test.go
+++ b/examples_test.go
@@ -1,7 +1,7 @@
 package approvals_test
 
 import (
-	approvals "github.com/approvals/go-approval-tests"
+	approvals "github.com/customerio/go-approval-tests"
 )
 
 func ExampleVerifyString() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/approvals/go-approval-tests
+module github.com/customerio/go-approval-tests
 
 go 1.12

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/approvals/go-approval-tests/reporters"
-	"github.com/approvals/go-approval-tests/utils"
+	"github.com/customerio/go-approval-tests/reporters"
+	"github.com/customerio/go-approval-tests/utils"
 )
 
 // TestFailable is a fake replacing testing.T

--- a/reporters/diff_reporter.go
+++ b/reporters/diff_reporter.go
@@ -3,7 +3,7 @@ package reporters
 import (
 	"os/exec"
 
-	"github.com/approvals/go-approval-tests/utils"
+	"github.com/customerio/go-approval-tests/utils"
 )
 
 // NewFrontLoadedReporter creates the default front loaded reporter.

--- a/reporters/quiet.go
+++ b/reporters/quiet.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/approvals/go-approval-tests/utils"
+	"github.com/customerio/go-approval-tests/utils"
 )
 
 type quiet struct{}

--- a/reporters/real_diff_reporter.go
+++ b/reporters/real_diff_reporter.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/approvals/go-approval-tests/utils"
+	"github.com/customerio/go-approval-tests/utils"
 )
 
 type realDiff struct{}

--- a/reporters/reporter_test.go
+++ b/reporters/reporter_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/approvals/go-approval-tests/utils"
+	"github.com/customerio/go-approval-tests/utils"
 )
 
 type testReporter struct {

--- a/scrubber_test.go
+++ b/scrubber_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	approvals "github.com/approvals/go-approval-tests"
+	approvals "github.com/customerio/go-approval-tests"
 )
 
 func TestVerifyDoesNotAcceptSeveralVerifyOptions(t *testing.T) {


### PR DESCRIPTION
Is there a reason why we kept the module name as [github.com/approvals/go-approval-tests](http://github.com/approvals/go-approval-tests) when we forked https://github.com/customerio/go-approval-tests/ ?

This requires that code using our fork needs to use replace in go.mod, e.g.: replace [github.com/approvals/go-approval-tests](http://github.com/approvals/go-approval-tests) => [github.com/customerio/go-approval-tests](http://github.com/customerio/go-approval-tests) v0.0.0-20240326142109-312e54345eb4 .

I'm finding this causes problems when doing go mod tidy on a module that depends on another module that uses go-approval-tests in its tests.

I wonder if we can rename our fork and simplify our go.mod files?

Note: In this PR, I have renamed our fork. :)

```bash
rdawe@Richard-Dawe customerio-go-approval-tests % (find . -name '*.go' && find . -name 'go.*') | xargs grep approvals/go-approval-tests
rdawe@Richard-Dawe customerio-go-approval-tests %
```

# TODOs

- [x] Verify this version is usable in the services tests https://github.com/customerio/services/pull/10817
- [x] Verify this version is usable in the cdp tests https://github.com/customerio/cdp/pull/2678
- [ ] Verify this version is usable in the edge tests
  - [ ] Interestingly edge still uses the regular go-approval-tests, and not our fork. Should it use our fork?
- [x] Add a note to the README about why this fork exists
- [ ] Run tests as part of PR workflows
  - [ ] I tried, but it didn't work, not sure why. (They pass when I run them locally.)
